### PR TITLE
Temporarily use 'typings' instead of 'types' for pre-2.0 users.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.4",
   "description": "angular2-data-table is a Angular2 component for presenting large and complex data.",
   "main": "release/angular2-data-table.umd.js",
-  "types": "release/angular2-data-table.d.ts",
+  "typings": "release/angular2-data-table.d.ts",
   "scripts": {
     "check": "npm-check --skip-unused",
     "test": "npm run lint",


### PR DESCRIPTION
This should help out users who aren't using 2.0 yet as I brought up on https://github.com/swimlane/angular2-data-table/issues/1#issuecomment-240618399.