### PR TITLE
Bug fix onPaged event emit wrong property name

### DIFF
--- a/src/components/footer/Pager.ts
+++ b/src/components/footer/Pager.ts
@@ -112,7 +112,7 @@ export class DataTablePager {
 
       this.onPaged.emit({
         type: 'pager-event',
-        value: page
+        page: page
       });
     }
   }


### PR DESCRIPTION
Updated Pager component onPaged event property name from 'value' => 'page' to match DataTable component event onPageChanged