### PR TITLE
fixed dependencies for rc6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,7 @@
     "@angular/core": "2.0.0-rc.6",
     "@angular/platform-browser": "2.0.0-rc.6",
     "@angular/platform-browser-dynamic": "2.0.0-rc.6",
-    "core-js": "^2.4.0",
-    "rxjs": "5.0.0-beta.6",
-    "zone.js": "0.6.17"
+    "core-js": "^2.4.0"
   },
   "devDependencies": {
     "@angular/common": "2.0.0-rc.6",
@@ -63,7 +61,7 @@
     "@angular/platform-browser": "2.0.0-rc.6",
     "@angular/platform-browser-dynamic": "2.0.0-rc.6",
     "core-js": "^2.4.0",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "zone.js": "0.6.17",
     "@angularclass/hmr": "^1.0.1",
     "@angularclass/hmr-loader": "^1.0.1",


### PR DESCRIPTION
I removed the rxjs & zonejs peer dependencies, as @angular already requires them for 2 reasons:
- angular 2 is loose on the zone js dependency, which mean that we can use a newer version when needed (for example 0.6.17 has a serious bug with longtrace)
- angular 2 requires rxjs beta 11 when your lib wanted beta 6