### PR TITLE
Allow configuration table Height in pixels with TableOptions property tableHeight.

### DIFF
--- a/src/demos/virtual.ts
+++ b/src/demos/virtual.ts
@@ -44,7 +44,8 @@ export class App {
     headerHeight: 50,
     footerHeight: 50,
     rowHeight: 50,
-    scrollbarV: true
+    scrollbarV: true,
+    tableHeight: 500
   });
 
   constructor() {

--- a/src/models/TableOptions.ts
+++ b/src/models/TableOptions.ts
@@ -40,6 +40,9 @@ export class TableOptions {
   // pass falsey for no footer
   footerHeight: number = 0;
 
+  // The minimum table height in pixels.
+  tableHeight: number = 300;
+
   // if external paging is turned on
   externalPaging: boolean = false;
 

--- a/src/services/State.ts
+++ b/src/services/State.ts
@@ -24,7 +24,15 @@ export class StateService {
   offsetX: number = 0;
   offsetY: number = 0;
   innerWidth: number = 0;
-  bodyHeight: number = 300;
+
+  private bodyheight: number;
+  set bodyHeight(value: number)
+  {
+    this.bodyheight = value;
+  }
+  get bodyHeight(): number {
+    return this.bodyheight || (this.options.tableHeight - this.options.headerHeight - this.options.footerHeight);
+  }
 
   get columnsByPin() {
     return columnsByPin(this.options.columns);


### PR DESCRIPTION
I wanted a way to enable the table height to be configurable and could not find an option to do this.

I using the table option with scrolling, not pagination.