### PR TITLE
Fix issue when specifying column width in HTML Element.

### DIFF
--- a/src/demos/virtual.ts
+++ b/src/demos/virtual.ts
@@ -14,19 +14,19 @@ import '../themes/material.scss';
         (onPageChange)="paged($event)"
         [options]='options'>
 
-        <datatable-column name="Name">
+        <datatable-column name="Name" width="220">
           <template let-value="value">
             <strong>{{value}}</strong>
           </template>
         </datatable-column>
 
-        <datatable-column name="Gender">
+        <datatable-column name="Gender" width="320">
           <template let-row="row" let-value="value">
             <i [innerHTML]="row['name']"></i> and <i>{{value}}</i>
           </template>
         </datatable-column>
 
-        <datatable-column name="Age">
+        <datatable-column name="Age" width="75">
         </datatable-column>
 
       </datatable>

--- a/src/models/TableColumn.ts
+++ b/src/models/TableColumn.ts
@@ -38,13 +38,25 @@ export class TableColumn {
   flexGrow: number = 0;
 
   // Minimum width of the column.
-  minWidth: number = 0;
+  get minWidth(): number {
+    return this._minWidth;
+  }
+  set minWidth(value: number) {
+    this._minWidth = +value;
+  }
+  _minWidth: number = 0;
 
   // Maximum width of the column.
   maxWidth: number = undefined;
 
   // The width of the column; by default (in pixels).
-  width: number = 150;
+  get width(): number {
+    return this._width;
+  }
+  set width(value: number) {
+    this._width = +value;
+  }
+  private _width: number = 150;
 
   // If yes then the column can be resized; otherwise it cannot.
   resizeable: boolean = true;

--- a/src/utils/column.ts
+++ b/src/utils/column.ts
@@ -49,7 +49,7 @@ export function columnTotalWidth(columns, prop?) {
   if(columns) {
     for(let c of columns) {
       let has = prop && c[prop];
-      totalWidth = totalWidth + (has ? c[prop] : c.width);
+      totalWidth = totalWidth + (has ? +c[prop] : +c.width);
     }
   }
 

--- a/src/utils/column.ts
+++ b/src/utils/column.ts
@@ -49,7 +49,7 @@ export function columnTotalWidth(columns, prop?) {
   if(columns) {
     for(let c of columns) {
       let has = prop && c[prop];
-      totalWidth = totalWidth + (has ? +c[prop] : +c.width);
+      totalWidth = totalWidth + (has ? c[prop] : c.width);
     }
   }
 

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -10,7 +10,7 @@ export function columnTotalWidth(columns: any, prop?: any) {
 
   for(let column of columns) {
     const has = prop && column[prop];
-    totalWidth = totalWidth + (has ? +column[prop] : +column.width);
+    totalWidth = totalWidth + (has ? column[prop] : column.width);
   }
 
   return totalWidth;
@@ -57,8 +57,8 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
   for(let attr in colsByGroup) {
     for(let column of colsByGroup[attr]) {
       if (!column.canAutoResize) {
-        maxWidth -= +column.width;
-        totalFlexGrow -= +column.flexGrow;
+        maxWidth -= column.width;
+        totalFlexGrow -= column.flexGrow;
       } else {
         column.width = 0;
       }
@@ -77,10 +77,10 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
       for(let column of colsByGroup[attr]) {
         // if the column can be resize and it hasn't reached its minimum width yet
         if (column.canAutoResize && !hasMinWidth[column.prop]) {
-          let newWidth = +column.width + +column.flexGrow * widthPerFlexPoint;
+          let newWidth = column.width + column.flexGrow * widthPerFlexPoint;
           if (column.minWidth !== undefined && newWidth < column.minWidth) {
-            remainingWidth += newWidth - +column.minWidth;
-            column.width = +column.minWidth;
+            remainingWidth += newWidth - column.minWidth;
+            column.width = column.minWidth;
             hasMinWidth[column.prop] = true;
           } else {
             column.width = newWidth;
@@ -122,31 +122,31 @@ export function forceFillColumnWidths(allColumns: any, expectedWidth: any, start
 
   for(let column of allColumns) {
     if(!column.canAutoResize) {
-      contentWidth += +column.width;
+      contentWidth += column.width;
     } else {
-      contentWidth += (+column.$$oldWidth || +column.width);
+      contentWidth += (column.$$oldWidth || column.width);
     }
   }
 
-  let remainingWidth = +expectedWidth - contentWidth;
+  let remainingWidth = expectedWidth - contentWidth;
   let additionWidthPerColumn = remainingWidth / columnsToResize.length;
   let exceedsWindow = contentWidth > expectedWidth;
 
   for(let column of columnsToResize) {
     if(exceedsWindow) {
-      column.width = +column.$$oldWidth || +column.width;
+      column.width = column.$$oldWidth || column.width;
     } else {
       if(!column.$$oldWidth) {
-        column.$$oldWidth = +column.width;
+        column.$$oldWidth = column.width;
       }
 
       const newSize = column.$$oldWidth + additionWidthPerColumn;
-      if(column.minWith && newSize < +column.minWidth) {
-        column.width = +column.minWidth;
-      } else if(column.maxWidth && newSize > +column.maxWidth) {
-        column.width = +column.maxWidth;
+      if(column.minWith && newSize < column.minWidth) {
+        column.width = column.minWidth;
+      } else if(column.maxWidth && newSize > column.maxWidth) {
+        column.width = column.maxWidth;
       } else {
-        column.width = +newSize;
+        column.width = newSize;
       }
     }
   }

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -10,7 +10,7 @@ export function columnTotalWidth(columns: any, prop?: any) {
 
   for(let column of columns) {
     const has = prop && column[prop];
-    totalWidth = totalWidth + (has ? column[prop] : column.width);
+    totalWidth = totalWidth + (has ? +column[prop] : +column.width);
   }
 
   return totalWidth;
@@ -57,8 +57,8 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
   for(let attr in colsByGroup) {
     for(let column of colsByGroup[attr]) {
       if (!column.canAutoResize) {
-        maxWidth -= column.width;
-        totalFlexGrow -= column.flexGrow;
+        maxWidth -= +column.width;
+        totalFlexGrow -= +column.flexGrow;
       } else {
         column.width = 0;
       }
@@ -77,10 +77,10 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
       for(let column of colsByGroup[attr]) {
         // if the column can be resize and it hasn't reached its minimum width yet
         if (column.canAutoResize && !hasMinWidth[column.prop]) {
-          let newWidth = column.width  + column.flexGrow * widthPerFlexPoint;
+          let newWidth = +column.width + +column.flexGrow * widthPerFlexPoint;
           if (column.minWidth !== undefined && newWidth < column.minWidth) {
-            remainingWidth += newWidth - column.minWidth;
-            column.width = column.minWidth;
+            remainingWidth += newWidth - +column.minWidth;
+            column.width = +column.minWidth;
             hasMinWidth[column.prop] = true;
           } else {
             column.width = newWidth;
@@ -122,31 +122,31 @@ export function forceFillColumnWidths(allColumns: any, expectedWidth: any, start
 
   for(let column of allColumns) {
     if(!column.canAutoResize) {
-      contentWidth += column.width;
+      contentWidth += +column.width;
     } else {
-      contentWidth += (column.$$oldWidth || column.width);
+      contentWidth += (+column.$$oldWidth || +column.width);
     }
   }
 
-  let remainingWidth = expectedWidth - contentWidth;
+  let remainingWidth = +expectedWidth - contentWidth;
   let additionWidthPerColumn = remainingWidth / columnsToResize.length;
   let exceedsWindow = contentWidth > expectedWidth;
 
   for(let column of columnsToResize) {
     if(exceedsWindow) {
-      column.width = column.$$oldWidth || column.width;
+      column.width = +column.$$oldWidth || +column.width;
     } else {
       if(!column.$$oldWidth) {
-        column.$$oldWidth = column.width;
+        column.$$oldWidth = +column.width;
       }
 
       const newSize = column.$$oldWidth + additionWidthPerColumn;
-      if(column.minWith && newSize < column.minWidth) {
-        column.width = column.minWidth;
-      } else if(column.maxWidth && newSize > column.maxWidth) {
-        column.width = column.maxWidth;
+      if(column.minWith && newSize < +column.minWidth) {
+        column.width = +column.minWidth;
+      } else if(column.maxWidth && newSize > +column.maxWidth) {
+        column.width = +column.maxWidth;
       } else {
-        column.width = newSize;
+        column.width = +newSize;
       }
     }
   }


### PR DESCRIPTION
When calculating column widths they are not converted to number for the width calculation. 

The width is a string value and the width calculation is concat strings rather than summing column widths.
