### PR TITLE
Fix issue when column height when column value is null

### DIFF
--- a/src/components/body/BodyCell.ts
+++ b/src/components/body/BodyCell.ts
@@ -37,11 +37,11 @@ export class DataTableBodyCell {
     return userPipe ? userPipe.transform(prop) : prop;
   }
 
-  @HostBinding('style.width') get width() {
-    return this.column.width + 'px';
+  @HostBinding('style.width.px') get width() {
+    return this.column.width;
   }
 
-  @HostBinding('style.height') get height() {
+  @HostBinding('style.height.px') get height() {
     return this.state.options.rowHeight;
   }
 

--- a/src/components/body/BodyCell.ts
+++ b/src/components/body/BodyCell.ts
@@ -1,6 +1,7 @@
 import { Component, Input, PipeTransform, HostBinding, ElementRef } from '@angular/core';
 import { TableColumn } from '../../models/TableColumn';
 import { deepValueGetter } from '../../utils/deepGetter';
+import { StateService } from '../../services/State';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -25,7 +26,7 @@ export class DataTableBodyCell {
   @Input() column: TableColumn;
   @Input() row: any;
 
-  constructor(element: ElementRef) {
+  constructor(private state: StateService, element: ElementRef) {
     element.nativeElement.classList.add('datatable-body-cell');
   }
 
@@ -38,6 +39,10 @@ export class DataTableBodyCell {
 
   @HostBinding('style.width') get width() {
     return this.column.width + 'px';
+  }
+
+  @HostBinding('style.height') get height() {
+    return this.state.options.rowHeight;
   }
 
 }


### PR DESCRIPTION
The column height is not correct when column value is null.

Main issue here is specifying column borders in stylesheet when value is null, the column border is only rendered for the top part of the column not the full height.
