### PR TITLE
Method guard State.setRows

### DIFF
--- a/src/services/State.ts
+++ b/src/services/State.ts
@@ -82,10 +82,8 @@ export class StateService {
   }
 
   setRows(rows: Array<any>): StateService {
-    if (rows) {
-      this.rows = [...rows];
-      this.onRowsUpdate.emit(rows);
-    }
+    this.rows = rows === undefined || rows === null ? [] : [...rows];
+    this.onRowsUpdate.emit(rows);
     return this;
   }
 


### PR DESCRIPTION
When consuming the table, I set rows to null when there are no rows present, so need the rows to be cleared. This is especially the case when the rows have not been initialized.

This causes a flow on affect in DataTableBody.ngOnInit() where reading the rows causes an exception.
