### PR TITLE
Fix bunching of rows on Initial Load when using VScroll

### DIFF
--- a/src/components/body/Body.ts
+++ b/src/components/body/Body.ts
@@ -93,6 +93,7 @@ export class DataTableBody implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.rows = [...this.state.rows];
+    this.updateRows();
 
     this.sub = this.state.onPageChange.subscribe((action) => {
       this.updateRows();


### PR DESCRIPTION
This solves the issues mentioned in #86 and #127 thanks to @marjan-georgiev for the initial investigation work to help figure this one out.