### PR TITLE
Ensure minWidth and maxWidth values are specified saved as numbers

### DIFF
--- a/src/demos/module.ts
+++ b/src/demos/module.ts
@@ -12,7 +12,7 @@ import '../components/datatable.scss';
 // import { App } from './sorting-server';
 // import { App } from './sorting-client';
 // import { App } from './selection';
-// import { App } from './virtual';
+import { App } from './virtual';
 // import { App } from './inline';
 // import { App } from './scrolling';
 // import { App } from './pinning';
@@ -22,7 +22,7 @@ import '../components/datatable.scss';
 // import { App } from './column-force';
 // import { App } from './column-flex';
 // import { App } from './fullscreen';
-import { App } from './template-dom';
+// import { App } from './template-dom';
 // import { App } from './template-obj';
 
 @NgModule({

--- a/src/demos/virtual.ts
+++ b/src/demos/virtual.ts
@@ -14,19 +14,19 @@ import '../themes/material.scss';
         (onPageChange)="paged($event)"
         [options]='options'>
 
-        <datatable-column name="Name">
+        <datatable-column name="Name" width="200">
           <template let-value="value">
             <strong>{{value}}</strong>
           </template>
         </datatable-column>
 
-        <datatable-column name="Gender">
+        <datatable-column name="Gender" width="300">
           <template let-row="row" let-value="value">
             <i [innerHTML]="row['name']"></i> and <i>{{value}}</i>
           </template>
         </datatable-column>
 
-        <datatable-column name="Age">
+        <datatable-column name="Age" width="80">
         </datatable-column>
 
       </datatable>
@@ -40,11 +40,11 @@ export class App {
   timeout: any;
 
   options = new TableOptions({
-    columnMode: ColumnMode.force,
+    columnMode: ColumnMode.standard,
     headerHeight: 50,
     footerHeight: 50,
     rowHeight: 50,
-    scrollbarV: true
+    scrollbarV: true,
   });
 
   constructor() {

--- a/src/models/table-column.model.ts
+++ b/src/models/table-column.model.ts
@@ -40,13 +40,23 @@ export class TableColumn {
   flexGrow: number = 0;
 
   // Minimum width of the column.
-  minWidth: number = 0;
+  get minWidth(): number {
+    return this._minWidth;
+  }
+  set minWidth(value: number) {
+    this._minWidth = +value;
+  }
 
   // Maximum width of the column.
   maxWidth: number = undefined;
 
   // The width of the column; by default (in pixels).
-  width: number = 150;
+  get width(): number {
+    return this._width;
+  }
+  set width(value: number) {
+    this._width = +value;
+  }
 
   // If yes then the column can be resized; otherwise it cannot.
   resizeable: boolean = true;
@@ -77,6 +87,9 @@ export class TableColumn {
 
   // ng2 template ref
   headerTemplate: any;
+
+  private _width: number = 150;
+  private _minWidth: number = 0;
 
   constructor(props?: any) {
     Object.assign(this, props);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Column minWidth and maxWidth specified in html are stored as strings, so when the calculation of the total widths are done it is string concatenation not summing values. 

**What is the new behavior?**

Convert minWidth and maxWidth to number when the values are set so that total width calculation works correctly.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

