### PR TITLE
Add row double click option

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -13,7 +13,7 @@ import {
 import { Subscription } from 'rxjs/Subscription';
 import { Keys, selectRows, selectRowsBetween, translateXY } from '../../utils';
 import { StateService } from '../../services';
-import { SelectionType } from '../../types';
+import { SelectionType, ClickType } from '../../types';
 import { Scroller } from '../../directives';
 
 @Component({
@@ -38,6 +38,7 @@ import { Scroller } from '../../directives';
           *ngFor="let row of rows; let i = index; trackBy: trackRowBy"
           [attr.tabindex]="i"
           (click)="rowClicked($event, i, row)"
+          (dblclick)="rowClicked($event, i, row)"
           (keydown)="rowKeydown($event, i, row)"
           [row]="row"
           [class.datatable-row-even]="row.$$index % 2 === 0"
@@ -190,7 +191,8 @@ export class DataTableBody implements OnInit, OnDestroy {
   }
 
   rowClicked(event, index, row): void {
-    this.onRowClick.emit({event, row});
+    let clickType = event.type === 'dblclick' ? ClickType.double : ClickType.single;
+    this.onRowClick.emit({ type: clickType, event, row });
     this.selectRow(event, index, row);
   }
 

--- a/src/demos/virtual.ts
+++ b/src/demos/virtual.ts
@@ -12,6 +12,7 @@ import '../themes/material.scss';
         class='material'
         [rows]='rows'
         (onPageChange)="paged($event)"
+        (onRowClick)="rowClick($event)"
         [options]='options'>
 
         <datatable-column name="Name">
@@ -71,4 +72,7 @@ export class App {
     req.send();
   }
 
+  rowClick(args) {
+    console.log('rowClick', args);
+  }
 }

--- a/src/types/click.type.ts
+++ b/src/types/click.type.ts
@@ -1,0 +1,4 @@
+export enum ClickType {
+  single = 'single' as any,
+  double = 'double' as any  
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './column-mode.type';
 export * from './sort.type';
 export * from './sort-direction.type';
 export * from './selection.type';
+export * from './click.type';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Table does not currently have support of double click on a row.

**What is the new behavior?**

When click or double click on a row the rowClick event is fired with a type of click.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Redo of PR #145 