### PR TITLE
Removed package.json engine restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
     "release:css": "node-sass -o release/ src/themes && node-sass -o release/ src/components",
     "release:minify": "uglifyjs release/index.js --source-map release/index.min.js.map --source-map-url release/index.js.map --compress --mangle --screw-ie8 --output release/index.min.js"
   },
-  "engines": {
-    "node": "~6.0.0"
-  },
-  "engineStrict": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/swimlane/angular2-data-table.git"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
The lib restricts the engine to node ~6.0.0 for no reason (this lib doesn't use any binary). This is a problem when using Yarn because it is more strict than npm and it will respect the engine restrictions which will fail the installation of all the npm modules with the following error message:
`error angular2-data-table@0.9.3: The engine "node" is incompatible with this module. Expected version "~6.0.0".`


**What is the new behavior?**
Removed the restriction


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No