### PR TITLE
fix(scroller): count scroll height with limit if defined

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -31,6 +31,7 @@ import { Scroller } from '../../directives';
         [scrollbarV]="state.options.scrollbarV"
         [scrollbarH]="state.options.scrollbarH"
         [count]="state.rowCount"
+        [limit]="state.options.limit"
         [scrollWidth]="state.columnGroupWidths.total">
         <datatable-body-row
           [ngStyle]="getRowsStyles(row)"

--- a/src/directives/scroller.directive.ts
+++ b/src/directives/scroller.directive.ts
@@ -19,6 +19,7 @@ export class Scroller implements OnInit, OnDestroy {
 
   @Input() rowHeight: number;
   @Input() count: number;
+  @Input() limit: number;
   @Input() scrollWidth: number;
   @Input() scrollbarV: boolean = false;
   @Input() scrollbarH: boolean = false;
@@ -33,7 +34,10 @@ export class Scroller implements OnInit, OnDestroy {
   private parentElement: any;
 
   get scrollHeight() {
-    return (this.count * this.rowHeight) + 'px';
+
+    const count = this.limit || this.count;
+
+    return (count * this.rowHeight) + 'px';
   }
 
   constructor(element: ElementRef) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

scroller.directive.ts counts wrong scroll height when rowHeight is fixed.
https://plnkr.co/edit/urYwQGQbJllLuXxVI8aA?p=preview

**What is the new behavior?**

scroller.directive.ts prefers limit before count input only if limit is defined or > 0

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:

It fixes use-case of paging with fixed rowHeight.
plunker:
https://plnkr.co/edit/urYwQGQbJllLuXxVI8aA?p=preview