### PR TITLE
(fix): Fixed bugs in Row Detail feature  when virtual scrolling is not set

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -117,15 +117,18 @@ export class DataTableBody implements OnInit, OnDestroy {
     });
 
     this.sub.add(this.state.onExpandChange.subscribe( (expandedState) => {
-      // If there was more than one row expanded then there was a mass change
-      // in the data set hence adjust the scroll position.
-      if (expandedState.rows.length > 1) {
-        // -1 is added to the scrollOffset as we want to move the scroller to the offset position
-        // where the entire row is visible. What about the small offset e.g. if the scroll
-        // position is between rows?  Do we need to take care of it?
-        let scrollOffset = this.state.rowHeightsCache.query(expandedState.currentIndex);
-        // Set the offset only after the scroll bar has been updated on the screen.
-        setTimeout(() => this.scroller.setOffset(scrollOffset));
+
+      if(this.state.options.scrollbarV) {
+        // If there was more than one row expanded then there was a mass change
+        // in the data set hence adjust the scroll position.
+        if (expandedState.rows.length > 1) {
+          // -1 is added to the scrollOffset as we want to move the scroller to the offset position
+          // where the entire row is visible. What about the small offset e.g. if the scroll
+          // position is between rows?  Do we need to take care of it?
+          let scrollOffset = this.state.rowHeightsCache.query(expandedState.currentIndex);
+          // Set the offset only after the scroll bar has been updated on the screen.
+          setTimeout(() => this.scroller.setOffset(scrollOffset));
+        }
       }
 
     }));

--- a/src/utils/row-height-cache.ts
+++ b/src/utils/row-height-cache.ts
@@ -31,6 +31,15 @@ export class RowHeightCache {
    * @param detailRowHeight The detail row height.
    */
   initCache ( rows: Array<any>, rowHeight: number, detailRowHeight: number) {
+    if (isNaN(rowHeight)) {
+      throw new Error(`Row Height cache initialization failed. Please ensure that 'rowHeight' is a
+        valid number value: (${rowHeight}) when 'scrollbarV' is enabled.`);
+    }
+    // Add this additional guard in case detailRowHeight is set to 'auto' as it wont work.
+    if (isNaN(detailRowHeight)) {
+      throw new Error(`Row Height cache initialization failed. Please ensure that 'detailRowHeight' is a
+        valid number value: (${detailRowHeight}) when 'scrollbarV' is enabled.`);
+    }
     const n = rows.length;
     this._treeArray = new Array(n);
 
@@ -40,11 +49,9 @@ export class RowHeightCache {
 
     for(let i = 0; i < n; ++i) {
       let currentRowHeight = rowHeight;
-
       // Add the detail row height to the already expanded rows.
       // This is useful for the table that goes through a filter or sort.
-      const row = rows[i];
-      if (row && row.$$expanded === 1) {
+      if (rows[i].$$expanded === 1) {
         currentRowHeight += detailRowHeight;
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

#210

**What is the new behavior?**

Row height cache is only initialized when virtual scrolling is enabled.   In all other scenarios row calculations are automatically done.   Also takes this takes care of the bug mentioned in pull request #208.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

…t present.