### PR TITLE
fix for first click sorting. It used the previous value for the sorts…

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -459,10 +459,10 @@ export class DatatableComponent implements OnInit, AfterViewInit {
 
     if(column.comparator !== undefined) {
       if(typeof column.comparator === 'function') {
-        column.comparator(this.rows, this.sorts);
+        column.comparator(this.rows, sorts);
       }
     } else {
-      this.rows = sortRows(this.rows, this.sorts);
+      this.rows = sortRows(this.rows, sorts);
     }
 
     this.sorts = sorts;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When the user clicks on a column header to sort, the first click does not seem to do anything.
The second click sorts the rows.
see also https://github.com/swimlane/angular2-data-table/issues/254

**What is the new behavior?**
The rows are sorted on the first click of the column header.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

… when calling the sorting function. Changed it to use the sort that comes in from the event.