### PR TITLE
custom comparator does not update rows

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -1,0 +1,50 @@
+import {TestBed, async} from "@angular/core/testing";
+import {DatatableComponent} from "./datatable.component";
+import {Angular2DataTableModule} from "../datatable.module";
+describe('Datatable component', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ Angular2DataTableModule ]
+    });
+  });
+
+  beforeEach(async(() => {
+    TestBed.compileComponents();
+  }));
+
+  describe('When the column is sorted with a custom comparator', () => {
+
+    it('should return a new array', ()=> {
+      let fixture = TestBed.createComponent(DatatableComponent);
+      let initialRows = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 }
+      ];
+
+      fixture.componentInstance.rows = initialRows;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.rows).toBe(initialRows);
+
+      fixture.componentInstance.onColumnSort({
+        column: {
+          comparator: function (rows, sorts) {
+            let temp = [ ...rows ];
+            return temp;
+          }
+        }
+      });
+
+      fixture.componentInstance.sort
+        .subscribe(() => {
+          console.log('sorted event');
+        });
+
+      expect(fixture.componentInstance.rows).not.toBe(initialRows);
+    });
+  });
+
+});

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -459,7 +459,7 @@ export class DatatableComponent implements OnInit, AfterViewInit {
 
     if(column.comparator !== undefined) {
       if(typeof column.comparator === 'function') {
-        column.comparator(this.rows, sorts);
+        this.rows = column.comparator(this.rows, sorts);
       }
     } else {
       this.rows = sortRows(this.rows, sorts);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When a custom comparator for a column is configured, the table is not sorted.

**What is the new behavior?**
A custom comparator should return a new array, which will be picked up by the change detection and update the view.


**Does this PR introduce a breaking change?** (check one with "x")
- [x ] Yes
- [ ] No

Custom comparators HAVE TO return a new array.
Not sure if it'll break anything, but it is an API change. Also added test.

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

…detection can pick it up and update the view.