### PR TITLE
fix(row-height): protect row undefined

### DIFF
--- a/src/utils/row-height-cache.ts
+++ b/src/utils/row-height-cache.ts
@@ -54,7 +54,7 @@ export class RowHeightCache {
 
       // Add the detail row height to the already expanded rows.
       // This is useful for the table that goes through a filter or sort.
-      if (rows[i].$$expanded === 1) {
+      if (rows[i] && rows[i].$$expanded === 1) {
         currentRowHeight += detailRowHeight;
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When determining the row height, if using virtual scrolling the row might not be loaded yet.

When [checking if the row is expanded](https://github.com/swimlane/angular2-data-table/blob/master/release/utils/row-height-cache.js#L50) the row may not be loaded yet.

There is also an issue [here where you determine the height.](https://github.com/swimlane/angular2-data-table/blob/master/release/utils/row-height-cache.js#L41) If using paging from the server, you need to use total count, not the length of the rows to determine the height. I plan to fix that in another PR.

**What is the new behavior?**

Protect against the row not being loaded, by assuming it is not expanded.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

