### PR TITLE
fix(selection): init selection to empty array

### DIFF
--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -67,7 +67,7 @@ export class DataTableBodyComponent {
   @Input() detailRowHeight: any;
   @Input() emptyMessage: string;
   @Input() selectionType: SelectionType;
-  @Input() selected: any[];
+  @Input() selected: any[] = [];
   @Input() rowIdentity: any;
   @Input() rowDetailTemplate: any;
   @Input() selectCheck: any;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If the input `[selected]` is not initialized, then clicking on a row when the option `[selectionType]` is set will trigger an error:
```
error_handler.js:54 TypeError: Cannot read property 'slice' of undefined
    at DataTableSelectionComponent.selectRow (index.js:1194)
    at DataTableSelectionComponent.onActivate (index.js:1213)
    at View_DataTableBodyComponent3.handleEvent_2 (component.ngfactory.js:454)
    at View_DataTableBodyComponent3.<anonymous> (view.js:418)
    at SafeSubscriber.schedulerFn [as _next] (async.js:101)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:223)
    at SafeSubscriber.next (Subscriber.js:172)
    at Subscriber._next (Subscriber.js:125)
    at Subscriber.next (Subscriber.js:89)
    at EventEmitter.Subject.next (Subject.js:55)
    at EventEmitter.emit (async.js:81)
```


**What is the new behavior?**
The selection should work even if `[selected]` has not be initialized


**Does this PR introduce a breaking change?** (check one with "x")
- [x] No