### PR TITLE
Custom comparator should return new array

### DIFF
--- a/src/components/datatable.component.spec.ts
+++ b/src/components/datatable.component.spec.ts
@@ -1,0 +1,50 @@
+import {TestBed, async} from "@angular/core/testing";
+import {DatatableComponent} from "./datatable.component";
+import {Angular2DataTableModule} from "../datatable.module";
+describe('Datatable component', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ Angular2DataTableModule ]
+    });
+  });
+
+  beforeEach(async(() => {
+    TestBed.compileComponents();
+  }));
+
+  describe('When the column is sorted with a custom comparator', () => {
+
+    it('should return a new array', ()=> {
+      let fixture = TestBed.createComponent(DatatableComponent);
+      let initialRows = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 }
+      ];
+
+      fixture.componentInstance.rows = initialRows;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.rows).toBe(initialRows);
+
+      fixture.componentInstance.onColumnSort({
+        column: {
+          comparator: function (rows, sorts) {
+            let temp = [ ...rows ];
+            return temp;
+          }
+        }
+      });
+
+      fixture.componentInstance.sort
+        .subscribe(() => {
+          console.log('sorted event');
+        });
+
+      expect(fixture.componentInstance.rows).not.toBe(initialRows);
+    });
+  });
+
+});

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -460,7 +460,7 @@ export class DatatableComponent implements OnInit, AfterViewInit {
     if (this.externalSorting === false) {
       if(column.comparator !== undefined) {
         if(typeof column.comparator === 'function') {
-          column.comparator(this.rows, sorts);
+          this.rows = column.comparator(this.rows, sorts);
         }
       } else {
         this.rows = sortRows(this.rows, sorts);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Custom sort functions do not update the reference to the rows, which means the table is not updated.


**What is the new behavior?**
The table is updated when using a custom sort function


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
