### PR TITLE
Set default value for selected

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -122,7 +122,7 @@ export class DatatableComponent implements OnInit, AfterViewInit {
   }
 
   // Selected rows
-  @Input() selected: any[];
+  @Input() selected: any[] = [];
 
   // Enable vertical scrollbars
   @Input() scrollbarV: boolean = false;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X ] Bugfix

**What is the current behavior?** 

Selection ins't working because `selected` property of DataTableComponent is not initialise, then that property is passed down to `DatatableBodyComponent` and `DatatableSelectionComponent` through `@Input()`. So even if both `DatatableBodyComponent` and `DatatableSelectionComponent` have an initial value for `selected` it gets overridden.

**What is the new behavior?**
It works !


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No


Again, I've done that directly on github, tell if you want me to clone and build it.
