### PR TITLE
rowContextmenu output

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -22,6 +22,7 @@ import { Component } from '@angular/core';
               <li><a href="#" (click)="state='hidden'">Hidden On Load</a></li>
               <li><a href="#" (click)="state='live'">Live Data</a></li>
               <li><a href="#" (click)="state='rx'">RxJS</a></li>
+              <li><a href="#" (click)="state='contextmenu'">Context Menu</a></li>
             </ul>
           </li>
           <li>
@@ -87,6 +88,7 @@ import { Component } from '@angular/core';
         <tabs-demo *ngIf="state === 'hidden'"></tabs-demo>
         <live-data-demo *ngIf="state === 'live'"></live-data-demo>
         <rx-demo *ngIf="state === 'rx'"></rx-demo>
+        <contextmenu-demo *ngIf="state === 'contextmenu'"></contextmenu-demo>
 
         <!-- Paging -->
         <client-paging-demo *ngIf="state === 'client-paging'"></client-paging-demo>

--- a/demo/basic/contextmenu.ts
+++ b/demo/basic/contextmenu.ts
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'contextmenu-demo',
+  template: `
+    <div>
+      <h3>Context Menu EventEmitter</h3>
+      <div style="margin: 1em; padding: 0 1em; border: solid 1px #ccc; background: white;">
+        <p><strong>Note:</strong> angular2-data-table does not provide a context menu feature.
+        This demonstrates how you would access the <code>contextmenu</code> event
+        to display your own custom context menu.</p>
+        <p *ngIf="rawEvent"><strong>Mouse position:</strong> <code>(x: {{rawEvent?.x}}, y: {{rawEvent?.y}})</code></p>
+        <p *ngIf="contextmenuRow"><strong>Row:</strong> {{contextmenuRow?.name}}</p>
+      </div>
+      <datatable
+        class="material"
+        [rows]="rows"
+        [columns]="columns"
+        [columnMode]="'force'"
+        [headerHeight]="50"
+        [footerHeight]="50"
+        [rowHeight]="'auto'"
+        (rowContextmenu)="onContextMenu($event)">
+      </datatable>
+    </div>
+  `
+})
+export class ContextMenuDemoComponent {
+
+  rows = [];
+
+  columns = [
+    { prop: 'name' },
+    { name: 'Gender' },
+    { name: 'Company' }
+  ];
+
+  rawEvent: MouseEvent;
+  contextmenuRow: any;
+
+  constructor() {
+    this.fetch((data) => {
+      this.rows = data;
+    });
+  }
+
+  onContextMenu(contextMenuEvent) {
+    console.log(contextMenuEvent);
+    this.rawEvent = contextMenuEvent.event;
+    this.contextmenuRow = contextMenuEvent.row;
+    contextMenuEvent.event.preventDefault();
+    contextMenuEvent.event.stopPropagation();
+  }
+
+  fetch(cb) {
+    const req = new XMLHttpRequest();
+    req.open('GET', `assets/data/company.json`);
+
+    req.onload = () => {
+      cb(JSON.parse(req.response));
+    };
+
+    req.send();
+  }
+
+}

--- a/demo/module.ts
+++ b/demo/module.ts
@@ -20,6 +20,7 @@ import { FilterBarComponent } from './basic/filter';
 import { TabsDemoComponent } from './basic/tabs';
 import { LiveDataComponent } from './basic/live';
 import { RxDemoComponent } from './basic/rx';
+import { ContextMenuDemoComponent } from './basic/contextmenu';
 
 // -- Paging
 import { ClientPagingComponent } from './paging/paging-client';
@@ -79,7 +80,8 @@ import { ColumnPinningComponent } from './columns/pinning';
     LiveDataComponent,
     MultiShiftSelectionComponent,
     MultiDisableSelectionComponent,
-    RxDemoComponent
+    RxDemoComponent,
+    ContextMenuDemoComponent
   ],
   imports: [BrowserModule, Angular2DataTableModule],
   bootstrap: [AppComponent]

--- a/src/components/body/body-row-wrapper.component.ts
+++ b/src/components/body/body-row-wrapper.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, Renderer, ElementRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, Renderer, ElementRef, ChangeDetectionStrategy,
+  Output, EventEmitter, HostListener } from '@angular/core';
 
 @Component({
   selector: 'datatable-row-wrapper',
@@ -23,9 +24,14 @@ export class DataTableRowWrapperComponent {
   @Input() detailRowHeight: any;
   @Input() expanded: boolean = false;
   @Input() row: any;
+  @Output() rowContextmenu = new EventEmitter<{event: MouseEvent, row: any}>(false);
 
   constructor(element: ElementRef, renderer: Renderer) {
     renderer.setElementClass(element.nativeElement, 'datatable-row-wrapper', true);
   }
 
+  @HostListener('contextmenu', ['$event'])
+  public onContextmenu($event: MouseEvent): void {
+    this.rowContextmenu.emit({ event: $event, row: this.row });
+  }
 }

--- a/src/components/body/body.component.ts
+++ b/src/components/body/body.component.ts
@@ -35,7 +35,8 @@ import { ScrollerComponent } from './scroller.component';
           [rowDetailTemplate]="rowDetailTemplate"
           [detailRowHeight]="detailRowHeight"
           [row]="row"
-          [expanded]="row.$$expanded === 1">
+          [expanded]="row.$$expanded === 1"
+          (rowContextmenu)="rowContextmenu.emit($event)">
           <datatable-body-row
             tabindex="-1"
             [isSelected]="selector.getRowSelected(row)"
@@ -152,6 +153,7 @@ export class DataTableBodyComponent {
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() select: EventEmitter<any> = new EventEmitter();
   @Output() detailToggle: EventEmitter<any> = new EventEmitter();
+  @Output() rowContextmenu = new EventEmitter<{event: MouseEvent, row: any}>(false);
 
   @ViewChild(ScrollerComponent) scroller: ScrollerComponent;
 

--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -57,6 +57,7 @@ import { scrollbarWidth, setColumnDefaults, translateTemplates } from '../utils'
         [selectCheck]="selectCheck"
         (page)="onBodyPage($event)"
         (activate)="activate.emit($event)"
+        (rowContextmenu)="rowContextmenu.emit($event)"
         (select)="select.emit($event)"
         (detailToggle)="detailToggle.emit($event)"
         (scroll)="onBodyScroll($event)">
@@ -227,6 +228,7 @@ export class DatatableComponent implements OnInit, AfterViewInit {
   @Output() detailToggle: EventEmitter<any> = new EventEmitter();
   @Output() reorder: EventEmitter<any> = new EventEmitter();
   @Output() resize: EventEmitter<any> = new EventEmitter();
+  @Output() rowContextmenu = new EventEmitter<{event: MouseEvent, row: any}>(false);
 
   @HostBinding('class.fixed-header')
   get isFixedHeader() {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

No way to listen to the `contextmenu` event for a particular row.  You can wire up custom cell templates, but that doesn't capture right-clicks on the padding between cell contents.

**What is the new behavior?**

There is a new `rowContextmenu` synchronous EventEmitter that sends out the `contextmenu` event and the row data.  The EventEmitter needs to be synchronous so that the listener can run `event.preventDefault()` before the browser's default context menu has appeared.

This doesn't actually implement a context menu feature - it just allows other context menu libraries (like my own [angular2-contextmenu](https://github.com/isaacplmann/angular2-contextmenu)) to be used with it.

See the Basic: Context Menu demo for an example of usage.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


