### PR TITLE
Fix updating of table when filtering backend data

### DIFF
--- a/src/components/datatable.component.ts
+++ b/src/components/datatable.component.ts
@@ -241,7 +241,23 @@ export class DatatableComponent implements OnInit, AfterViewInit {
    * @type {number}
    * @memberOf DatatableComponent
    */
-  @Input() count: number = 0;
+  @Input() set count(val: number) {
+    this._count = val;
+
+    // recalculate sizes/etc
+    this.recalculate();
+  }
+
+  /**
+   * Gets the count.
+   * 
+   * @readonly
+   * @type {number}
+   * @memberOf DatatableComponent
+   */
+  get count(): number {
+    return this._count;
+  }
 
   /**
    * The current offset ( page - 1 ) shown. 
@@ -647,6 +663,7 @@ export class DatatableComponent implements OnInit, AfterViewInit {
 
   private _rows: any[];
   private _columns: any[];
+  private _count: number = 0;
   private _columnTemplates: QueryList<DataTableColumnDirective>;
   private _rowDetailTemplateChild: DatatableRowDetailDirective;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When filtering is done on a table backed by backend data (externalPaging) "rows" is bound first, recalculating. "count" is bound second resulting in a wrong "rowCount".

**What is the new behavior?**

When "count" is changed via binding a "this.recalculate();" is issued fixing the calculated "rowCount".

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x ] No

**Other information**:

Fixes:  When filtering is done on a table backed by backend data (externalPaging) "rows" is bound first, recalculating. "count" is bound second resulting in a wrong "rowCount".