### PR TITLE
Decorate header/cell templates with Input

### DIFF
--- a/src/components/columns/column.directive.ts
+++ b/src/components/columns/column.directive.ts
@@ -22,9 +22,11 @@ export class DataTableColumnDirective {
   @Input() checkboxable: boolean;
   @Input() headerCheckboxable: boolean;
 
+  @Input()
   @ContentChild(DataTableColumnCellDirective, { read: TemplateRef }) 
   cellTemplate: TemplateRef<any>;
 
+  @Input()
   @ContentChild(DataTableColumnHeaderDirective, { read: TemplateRef }) 
   headerTemplate: TemplateRef<any>;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 
Currently, header and cell templates are only able to be passed as `@ContentChild`


**What is the new behavior?**
Adding `@Input()` allows header/cell templates to be passed as inputs and be reused.


**Does this PR introduce a breaking change?** 
- [ ] Yes
- [x] No

**Other information**: I haven't looked deep into what kind of performance change this could bring, though I don't see it having too much of an effect.

